### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -2,6 +2,9 @@ name: Server
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/pyprism/Device-Chronicle/security/code-scanning/2](https://github.com/pyprism/Device-Chronicle/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/server.yaml` so the workflow clearly constrains `GITHUB_TOKEN` to least privilege.  
Best fix here: define workflow-level permissions right after `on`, with `contents: read`. This is sufficient for `actions/checkout@v4` and does not alter current behavior of building/testing code. No imports, methods, or dependencies are needed—only YAML configuration update in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
