### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -2,6 +2,9 @@ name: Client
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/pyprism/Device-Chronicle/security/code-scanning/1](https://github.com/pyprism/Device-Chronicle/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/client.yaml` at the workflow root, directly under the `on` section, so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing behavior (checkout/read operations still work) while preventing unintended write scopes from defaults. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
